### PR TITLE
Version 0.10.1.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ def read(fname):
     return content
 
 DEPS = [
-    'simple-workflow==0.1.56.1',
+    'simple-workflow==0.1.56.2',
     'tabulate==0.7.3',
     'setproctitle',
     'subprocess32',
@@ -81,7 +81,7 @@ DEPS = [
 
 def install_simple_workflow():
     import pip
-    pip.main(['install', 'https://s3-us-west-2.amazonaws.com/zenefits-packages/python-simple-workflow-0.1.56.1.tar.gz'])
+    pip.main(['install', 'https://s3-us-west-2.amazonaws.com/zenefits-packages/python-simple-workflow-0.1.56.2.tar.gz'])
 
 
 def main():

--- a/simpleflow/__init__.py
+++ b/simpleflow/__init__.py
@@ -12,4 +12,4 @@ __version__ = '0.10.1.1'
 __author__ = 'Greg Leclercq'
 __license__ = "MIT"
 
-logging.config.dictConfig(settings.base.load()['LOGGING'])
+# logging.config.dictConfig(settings.base.load()['LOGGING'])

--- a/simpleflow/__init__.py
+++ b/simpleflow/__init__.py
@@ -8,7 +8,7 @@ from .workflow import Workflow  # NOQA
 from . import settings
 
 
-__version__ = '0.10.1.1'
+__version__ = '0.10.1.2'
 __author__ = 'Greg Leclercq'
 __license__ = "MIT"
 

--- a/simpleflow/history.py
+++ b/simpleflow/history.py
@@ -153,6 +153,12 @@ class History(object):
                 activity['retry'] = 0
             else:
                 activity['retry'] += 1
+        elif event.state == 'cancel_requested':
+            activity = self._activities[event.activity_id]
+            activity['state'] = event.state
+            if hasattr(event, 'details'):
+                activity['details'] = event.details
+            activity['cancel_requested_timestamp'] = event.timestamp
         elif event.state == 'canceled':
             activity = get_activity(event)
             activity['state'] = event.state

--- a/simpleflow/swf/process/actor.py
+++ b/simpleflow/swf/process/actor.py
@@ -16,6 +16,7 @@ import swf.actors
 
 from simpleflow import utils
 from simpleflow.exceptions import TaskCancelled
+from threading import Event
 
 logger = logging.getLogger(__name__)
 
@@ -172,6 +173,7 @@ class Poller(NamedMixin, swf.actors.Actor):
                  task_list=None,
                  *args, **kwargs):
         self.is_alive = False
+        self.is_shutdown = Event()
         swf.actors.Actor.__init__(self, domain, task_list)
         super(Poller, self).__init__(
             domain,
@@ -229,6 +231,7 @@ class Poller(NamedMixin, swf.actors.Actor):
                 self.identity,
             )
             self.is_alive = False
+            self.is_shutdown.set()
             self.stop(graceful=True)
 
         # optionnally use faulthandler if available

--- a/simpleflow/swf/process/actor.py
+++ b/simpleflow/swf/process/actor.py
@@ -16,10 +16,11 @@ import swf.actors
 
 from simpleflow import utils
 from simpleflow.exceptions import TaskCancelled
+import threading
 from threading import Event
 
 logger = logging.getLogger(__name__)
-
+thread_local = threading.local()
 
 __all__ = ['Supervisor', 'Poller']
 

--- a/simpleflow/swf/process/actor.py
+++ b/simpleflow/swf/process/actor.py
@@ -269,6 +269,7 @@ class Poller(NamedMixin, swf.actors.Actor):
             except:
                 logger.exception("[%s] Unknow exception when polling on domain %s. Sleep for 1s.", self.name, self.domain.name)
                 time.sleep(1)
+                continue
 
             self.process(task)
 

--- a/simpleflow/swf/process/decider/base.py
+++ b/simpleflow/swf/process/decider/base.py
@@ -114,6 +114,8 @@ class DeciderPoller(swf.actors.Decider, Poller):
     def process(self, task):
         token, history = task
 
+        self.init_thread_local(history)
+
         logger.info('taking decision for workflow {}'.format(
             self._workflow_name))
         decisions = self.decide(history)
@@ -124,6 +126,15 @@ class DeciderPoller(swf.actors.Decider, Poller):
         except Exception as err:
             tb = traceback.format_exc()
             logger.error('cannot complete decision: {} {}'.format(err, tb))
+
+    def init_thread_local(self, history):
+        import uuid
+        from simpleflow.swf.process.actor import thread_local
+        thread_local.activity_id = uuid.uuid4()
+
+        if len(history) > 0:
+            workflow_started_event = history[0]
+            thread_local.workflow_input = getattr(workflow_started_event, 'input', '')
 
     @with_state('deciding')
     def decide(self, history):

--- a/simpleflow/swf/process/decider/base.py
+++ b/simpleflow/swf/process/decider/base.py
@@ -122,7 +122,8 @@ class DeciderPoller(swf.actors.Decider, Poller):
                 self._workflow_name))
             self._complete(token, decisions)
         except Exception as err:
-            logger.error('cannot complete decision: {}'.format(err))
+            tb = traceback.format_exc()
+            logger.error('cannot complete decision: {} {}'.format(err, tb))
 
     @with_state('deciding')
     def decide(self, history):
@@ -154,7 +155,7 @@ class DeciderWorker(object):
                 decisions = decisions[0]
         except Exception as err:
             tb = traceback.format_exc()
-            message = "workflow decision failed: {}".format(err)
+            message = "workflow decision failed: {}, {}".format(error, tb)
             logger.error(message)
             decision = swf.models.decision.WorkflowExecutionDecision()
             decision.fail(reason=swf.format.reason(message), details=tb)

--- a/simpleflow/swf/process/decider/base.py
+++ b/simpleflow/swf/process/decider/base.py
@@ -147,8 +147,8 @@ class DeciderWorker(object):
 
         """
         self._workflow_name = history[0].workflow_type['name']
-        workflow_executor = self._workflows[self._workflow_name]
         try:
+            workflow_executor = self._workflows[self._workflow_name]
             decisions = workflow_executor.replay(history)
             if isinstance(decisions, tuple) and len(decisions) == 2:  # (decisions, context)
                 decisions = decisions[0]

--- a/simpleflow/swf/process/worker/base.py
+++ b/simpleflow/swf/process/worker/base.py
@@ -122,7 +122,7 @@ class ActivityWorker(object):
             input = json.loads(task.input)
             args = input.get('args', ())
             kwargs = input.get('kwargs', {})
-            result = ActivityTask(activity, self.is_shutdown, *args, **kwargs).execute()
+            result = ActivityTask(activity, is_shutdown=self.is_shutdown, *args, **kwargs).execute()
         except TaskCancelled:
             raise
         except Exception as err:

--- a/simpleflow/swf/process/worker/base.py
+++ b/simpleflow/swf/process/worker/base.py
@@ -22,6 +22,7 @@ from simpleflow.exceptions import SoftTaskCancelled
 from simpleflow.exceptions import TaskCancelled
 from datetime import datetime
 from threading import Event
+import uuid
 
 logger = logging.getLogger(__name__)
 
@@ -72,7 +73,9 @@ class ActivityPoller(Poller, swf.actors.ActivityWorker):
     @with_state('processing task')
     def process(self, request):
         token, task = request
-        run_in_proc(self, token, task, self._heartbeat, self._soft_cancel_wait_period, self.is_shutdown)
+        activityId = uuid.uuid4()
+        init_thread_local(task, activityId)
+        run_in_proc(self, token, task, activityId, self._heartbeat, self._soft_cancel_wait_period, self.is_shutdown)
 
     @with_state('completing')
     def complete(self, token, result):
@@ -165,6 +168,12 @@ def monitor_child(pid, info):
 
     signal.signal(signal.SIGCHLD, _handle_child_exit)
 
+def init_thread_local(task, activityId):
+    from simpleflow.swf.process.actor import thread_local
+
+    thread_local.activity_id = activityId
+    thread_local.workflow_input = getattr(task, 'input', '')
+
 def registerTaskCancelHandler(isTaskFinished, poller, task):
     def signal_task_cancellation(signum, frame):
         logger.info(
@@ -183,14 +192,14 @@ def registerTaskCancelHandler(isTaskFinished, poller, task):
     signal.signal(signal.SIGUSR1, signal_task_cancellation)
     signal.signal(signal.SIGUSR2, signal_task_cancellation)
 
-def run_in_proc(poller, token, task, heartbeat=60, soft_cancel_wait_period=180, is_shutdown=None):
+def run_in_proc(poller, token, task, activity_id, heartbeat=60, soft_cancel_wait_period=180, is_shutdown=None):
     pid = os.getpid()
     isTaskFinished = threading.Event()
 
     registerTaskCancelHandler(isTaskFinished, poller, task)
 
     # start the heartbeat thread
-    heartbeat_thread = threading.Thread(target=start_heartbeat, args=(poller, token, task, isTaskFinished, heartbeat, pid, soft_cancel_wait_period))
+    heartbeat_thread = threading.Thread(target=start_heartbeat, args=(poller, token, task, isTaskFinished, heartbeat, pid, soft_cancel_wait_period, activity_id))
     heartbeat_thread.setDaemon(True)
     heartbeat_thread.start()
 
@@ -198,9 +207,9 @@ def run_in_proc(poller, token, task, heartbeat=60, soft_cancel_wait_period=180, 
     # start processing the task
     try:
         try:
-            logger.info('[SWF][Worker] Start processing task. Task: [%s].', task.activity_type.name)
+            logger.info('[SWF][Worker][%s] Start processing task. ', task.activity_type.name)
             process_task(poller, token, task, is_shutdown)
-            logger.info('[SWF][Worker] Finished processing task. Task: [%s].', task.activity_type.name)
+            logger.info('[SWF][Worker][%s] Finished processing task. ', task.activity_type.name)
         except TaskCancelled:
             # task is cancelled by the heartbeat thread from swf
             isTaskCancelled = True
@@ -221,25 +230,27 @@ def run_in_proc(poller, token, task, heartbeat=60, soft_cancel_wait_period=180, 
         heartbeat_thread.join()
 
     if isTaskCancelled:
-        logger.info('[SWF][Worker][Worker] Reporting task is cancelled. Task: [%s].', task.activity_type.name)
+        logger.info('[SWF][Worker][%s] Reporting task is cancelled.', task.activity_type.name)
 
         try:
             poller.cancel(token)
         except:
-            logger.info('[SWF][Worker][Worker] Failed to send task cancel confirmation to swf. Ignore. Task: [%s].', task.activity_type.name)
+            logger.info('[SWF][Worker][%s] Failed to send task cancel confirmation to swf. Ignore. ', task.activity_type.name)
 
-    logger.info('[SWF][Worker][Heartbeat] Heartbeat thread stopped. Task: [%s]', task.activity_type.name)
+    logger.info('[SWF][Worker][%s] Heartbeat thread stopped. ', task.activity_type.name)
 
 
-def start_heartbeat(poller, token, task, isTaskFinished, heartbeat, pid, soft_cancel_wait_period):
+def start_heartbeat(poller, token, task, isTaskFinished, heartbeat, pid, soft_cancel_wait_period, activity_id):
+    init_thread_local(task, activity_id)
 
-    cancel_requested_at = [None]
+    # [soft_timeout_requested_time, hard_timeout_requested_time]
+    cancel_requested_at = [None, None]
 
     def try_cancel_task():
 
         if cancel_requested_at[0] == None:
             # first time. Send a soft cancel
-            logger.info('[SWF][Worker][Heartbeat] Sending signal SIGUSR1 for soft cancellation. Task: [%s].', task.activity_type.name)
+            logger.info('[SWF][Worker][Heartbeat][%s] Sending signal SIGUSR1 for soft cancellation. ', task.activity_type.name)
             os.kill(int(pid), signal.SIGUSR1)
             cancel_requested_at[0] = datetime.utcnow()
         else:
@@ -248,16 +259,29 @@ def start_heartbeat(poller, token, task, isTaskFinished, heartbeat, pid, soft_ca
 
             if (now - cancel_requested_at[0]).total_seconds() >= soft_cancel_wait_period:
                 # time's up. Send a hard cancellation
-                logger.info('[SWF][Worker][Heartbeat] Sending signal SIGUSR2 for hard cancellation. Task: [%s].', task.activity_type.name)
-                os.kill(int(pid), signal.SIGUSR2)
+
+                if cancel_requested_at[1] == None:
+                    logger.info('[SWF][Worker][Heartbeat][%s] Sending signal SIGUSR2 for hard cancellation. ', task.activity_type.name)
+                    os.kill(int(pid), signal.SIGUSR2)
+                    cancel_requested_at[1] = datetime.utcnow()
+                else:
+                    logger.info('[SWF][Worker][Heartbeat][%s] Hard cancellation sent at [%s]. Waiting the task to be cancelled. ', task.activity_type.name, cancel_requested_at[1].isoformat())
+
+                    # exit the process after 1 min the hard timeout is sent
+                    if (now - cancel_requested_at[1]).total_seconds() >= 60:
+                        logger.error('[SWF][Worker][Heartbeat][%s] Hard cancellation sent at [%s]. Now forcing exiting the worker process. ', task.activity_type.name, cancel_requested_at[1].isoformat())
+
+                        import sys
+                        sys.exit(-1)
+
             else:
-                logger.info('[SWF][Worker][Heartbeat] Soft cancellation sent at [%s]. Waiting the task to be cancelled. Task: [%s].', cancel_requested_at[0].isoformat(), task.activity_type.name)
+                logger.info('[SWF][Worker][Heartbeat][%s] Soft cancellation sent at [%s]. Waiting the task to be cancelled. ', task.activity_type.name, cancel_requested_at[0].isoformat())
 
     while (not isTaskFinished.is_set()):
         isTaskFinished.wait(heartbeat)
         if (not isTaskFinished.is_set()):
             # task is still running
-            logger.info('[SWF][Worker][Heartbeat] Sending heartbeat. Task: [%s].', task.activity_type.name)
+            logger.info('[SWF][Worker][Heartbeat][%s] Sending heartbeat. ', task.activity_type.name)
 
             response = None
 
@@ -265,20 +289,20 @@ def start_heartbeat(poller, token, task, isTaskFinished, heartbeat, pid, soft_ca
                 response = poller.heartbeat(token)
             except swf.exceptions.DoesNotExistError:
                 # The workflow no long exist. It may timed out. Kill the process.
-                logger.info('[SWF][Worker][Heartbeat] Activity DoesNotExistError when sending heartbeat. Stopping the task. Task: [%s].', task.activity_type.name)
+                logger.info('[SWF][Worker][Heartbeat][%s] Activity DoesNotExistError when sending heartbeat. Stopping the task.', task.activity_type.name)
                 try_cancel_task()
 
             except Exception as error:
                 # Ignore if we failed to send heartbeat. The
                 # subprocess will become orphan and the heartbeat timeout may
                 # eventually trigger on Amazon SWF side.
-                logger.error('[SWF][Worker][Heartbeat] Cannot send heartbeat for task {}: {}'.format(
+                logger.error('[SWF][Worker][Heartbeat][{}] Cannot send heartbeat. {}'.format(
                     task.activity_type.name,
                     error))
 
             if response and response.get('cancelRequested'):
                 # Task cancelled.
-                logger.info('[SWF][Worker][Heartbeat] Activity received cancallaton request. Stopping the task. Task: [%s].', task.activity_type.name)
+                logger.info('[SWF][Worker][Heartbeat][%s] Activity received cancallaton request. Stopping the task.', task.activity_type.name)
                 try_cancel_task()
 
 

--- a/simpleflow/swf/process/worker/base.py
+++ b/simpleflow/swf/process/worker/base.py
@@ -130,11 +130,13 @@ class ActivityWorker(object):
         try:
             poller._complete(token, json.dumps(result))
         except Exception as err:
-            logger.exception(err)
-            reason = 'cannot complete task {}: {}'.format(
+            tb = traceback.format_exc()
+            reason = 'cannot complete task {}: {} {}'.format(
                 task.activity_id,
                 err,
+                tb
             )
+            logger.exception(reason)
             poller.fail(token, task, reason)
 
 

--- a/simpleflow/swf/process/worker/base.py
+++ b/simpleflow/swf/process/worker/base.py
@@ -113,12 +113,12 @@ class ActivityWorker(object):
         return self._dispatcher.dispatch_activity(name)
 
     def process(self, poller, token, task):
-        logger.debug('ActivityWorker.porcess() pid={}'.format(os.getpid()))
-        activity = self.dispatch(task)
-        input = json.loads(task.input)
-        args = input.get('args', ())
-        kwargs = input.get('kwargs', {})
         try:
+            logger.debug('ActivityWorker.porcess() pid={}'.format(os.getpid()))
+            activity = self.dispatch(task)
+            input = json.loads(task.input)
+            args = input.get('args', ())
+            kwargs = input.get('kwargs', {})
             result = ActivityTask(activity, self.is_shutdown, *args, **kwargs).execute()
         except TaskCancelled:
             raise

--- a/simpleflow/swf/task.py
+++ b/simpleflow/swf/task.py
@@ -43,6 +43,7 @@ class ActivityTask(task.ActivityTask):
 
         if task_timeout_override != None:
             task_timeout = str(task_timeout_override)
+            duration_timeout = str(task_timeout_override)
 
         decision = swf.models.decision.ActivityTaskDecision(
             'schedule',

--- a/simpleflow/task.py
+++ b/simpleflow/task.py
@@ -38,7 +38,7 @@ class Task(object):
                 key, val in kwargs.iteritems()}
 
 class ActivityTask(Task):
-    def __init__(self, activity, is_shutdown=None, *args, **kwargs):
+    def __init__(self, activity, *args, **kwargs):
         if not isinstance(activity, Activity):
             raise TypeError('Wrong value for `activity`, got {} instead'.format(type(activity)))
         self.activity = activity
@@ -46,7 +46,6 @@ class ActivityTask(Task):
         self.args = self.resolve_args(*args)
         self.kwargs = self.resolve_kwargs(**kwargs)
         self.id = None
-        self.is_shutdown = is_shutdown
 
     @property
     def name(self):
@@ -63,10 +62,6 @@ class ActivityTask(Task):
     def execute(self):
         method = self.activity._callable
         kwargs = self.kwargs
-
-        # add parameter is_shutdown to allow activity callable to gracefully shutdown
-        if self.is_shutdown:
-            kwargs = dict(self.kwargs, is_shutdown=self.is_shutdown)
 
         if hasattr(method, 'execute'):
             return method(*self.args, **kwargs).execute()


### PR DESCRIPTION
1. Propagate shutdown event to activity to allow graceful shutdown
2. Do not crash worker/decider if the workflow/activity is not known. Fail them instead.
3. Use thread local to log activity id and task input.
4. Force exit the process if we send hard timeout exception for more than 60 seconds.