### PR TITLE
remove setproctitle to fix the setproctitle.so: undefined symbol: Py_GetArgcArgv error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,6 @@ def read(fname):
 
 DEPS = [
     'tabulate==0.7.3',
-    'setproctitle==1.1.9',
     'subprocess32==3.2.6',
     'click==6.3',
     'psutil==4.0.0',

--- a/simpleflow/swf/process/actor.py
+++ b/simpleflow/swf/process/actor.py
@@ -10,7 +10,6 @@ import signal
 import sys
 import time
 
-from setproctitle import setproctitle
 
 import swf.actors
 
@@ -81,10 +80,6 @@ class Supervisor(object):
 
     def start(self):
         logger.info('starting {}'.format(self._payload))
-        setproctitle('{}(payload={})'.format(
-            self.__class__.__name__,
-            get_payload_name(self._payload),
-        ))
         assert len(self._processes) == 0
         for _ in xrange(self._nb_children):
             child = multiprocessing.Process(
@@ -166,7 +161,6 @@ class NamedMixin(object):
         if name is None:
             name = self.name
 
-        setproctitle('{}[{}]'.format(name, self.state))
 
 
 class Poller(NamedMixin, swf.actors.Actor):

--- a/tox.ini
+++ b/tox.ini
@@ -24,4 +24,3 @@ deps=
     pygments
     pytest
     click
-    setproctitle


### PR DESCRIPTION
simpleflow crashes with the below error while logging. setproctitle is not need to run workflows. 

```
Traceback (most recent call last):
  File "/var/www/yourpeople/hub/infra/eta/models.py", line 1434, in run_at
    eta = queue_task_to_backend(eta, raiseOnTaskAlreadyExists=True)
  File "/var/www/yourpeople/hub/infra/eta/models.py", line 1500, in queue_task_to_backend
    from swf_tasks.runner import start_single_task_workflow
  File "/var/www/yourpeople/venv/lib/python2.7/site-packages/swf_tasks/runner.py", line 7, in <module>
    from simpleflow.command import get_workflow, get_input, get_workflow_type
  File "/var/www/yourpeople/venv/lib/python2.7/site-packages/simpleflow/command.py", line 20, in <module>
    from simpleflow.swf.process import decider
  File "/var/www/yourpeople/venv/lib/python2.7/site-packages/simpleflow/swf/process/__init__.py", line 3, in <module>
    from .actor import Poller  # NOQA
  File "/var/www/yourpeople/venv/lib/python2.7/site-packages/simpleflow/swf/process/actor.py", line 13, in <module>
    from setproctitle import setproctitle
ImportError: /var/www/yourpeople/venv/lib/python2.7/site-packages/setproctitle.so: undefined symbol: Py_GetArgcArgv
```